### PR TITLE
Adding zero ex token lookup

### DIFF
--- a/src/utils/constants/constants.ts
+++ b/src/utils/constants/constants.ts
@@ -72,10 +72,10 @@ export const INDEX_TOKENS = {
 }
 
 export const INDEX_TOKENS_FOR_SELECT = [
-    { name: 'DPI' },
-    { name: 'MVI' },
-    { name: 'BED' },
-    { name: 'DATA' }
+  { name: 'DPI' },
+  { name: 'MVI' },
+  { name: 'BED' },
+  { name: 'DATA' }
 ]
 
 export const EXCHANGES: Array<ExchangeName> = [
@@ -84,6 +84,7 @@ export const EXCHANGES: Array<ExchangeName> = [
   'Sushiswap',
   'Kyber',
   'Balancer',
+  'ZeroEx',
 ]
 
 export const V2_FACTORY_ABI = [

--- a/src/utils/poolData/balancerV1.ts
+++ b/src/utils/poolData/balancerV1.ts
@@ -7,18 +7,14 @@ import {
 } from 'utils/constants/constants'
 import { getProvider } from 'utils/provider'
 import { ERC20_ABI, WETH } from 'utils/constants/tokens'
-
-type BalBalances = {
-  tokenBalance: BigNumber
-  wethBalance: BigNumber
-}
+import { LiquidityBalance } from './types'
 
 // Usage note, targetPriceImpact should be the impact including fees! Balancer pool fees can change and it's not easy to extract from the data
 // we have so put in a number that is net of fees.
 export async function getBalancerV1Liquidity(
   tokenAddress: string
-): Promise<BalBalances> {
-  let response: BalBalances = {
+): Promise<LiquidityBalance> {
+  let response = {
     tokenBalance: BigNumber.from(0),
     wethBalance: BigNumber.from(0),
   }
@@ -41,10 +37,8 @@ export async function getBalancerV1Liquidity(
 
   const reducer = (previousValue: BigNumber, currentValue: BigNumber) =>
     previousValue.add(currentValue)
-  response = {
+  return {
     tokenBalance: tokenBalances.reduce(reducer).div(TEN_POW_18),
     wethBalance: wethBalances.reduce(reducer).div(TEN_POW_18),
   }
-
-  return response
 }

--- a/src/utils/poolData/kyber.ts
+++ b/src/utils/poolData/kyber.ts
@@ -8,16 +8,12 @@ import {
 } from 'utils/constants/constants'
 import { WETH } from 'utils/constants/tokens'
 import { getProvider } from 'utils/provider'
-
-type KyberBalances = {
-  tokenBalance: BigNumber
-  wethBalance: BigNumber
-}
+import { LiquidityBalance } from './types'
 
 export async function getKyberLiquidity(
   tokenAddress: string
-): Promise<KyberBalances> {
-  let response: KyberBalances = {
+): Promise<LiquidityBalance> {
+  let response = {
     tokenBalance: BigNumber.from(0),
     wethBalance: BigNumber.from(0),
   }
@@ -34,8 +30,8 @@ export async function getKyberLiquidity(
   const pairContract = await new Contract(pools[0], KYBER_POOL_ABI, provider)
   const [tokenBalance, wethBalance] = await pairContract.getReserves()
 
-  response.tokenBalance = tokenBalance.div(TEN_POW_18)
-  response.wethBalance = tokenBalance.div(wethBalance)
-
-  return response
+  return {
+    tokenBalance: tokenBalance.div(TEN_POW_18),
+    wethBalance: wethBalance.div(TEN_POW_18)
+  }
 }

--- a/src/utils/poolData/sushiswap.ts
+++ b/src/utils/poolData/sushiswap.ts
@@ -8,15 +8,11 @@ import {
 
 import { WETH } from 'utils/constants/tokens'
 import { getProvider } from 'utils/provider'
-
-type V2Balances = {
-  tokenBalance: BigNumber
-  wethBalance: BigNumber
-}
+import { LiquidityBalance } from './types'
 
 export async function getSushiswapLiquidity(
   tokenAddress: string
-): Promise<V2Balances> {
+): Promise<LiquidityBalance> {
   const provider = getProvider()
   const factoryInstance = await new Contract(
     SUSHI_FACTORY,
@@ -31,9 +27,8 @@ export async function getSushiswapLiquidity(
   )
   const [tokenBalance, wethBalance] = await pairContract.getReserves()
 
-  const response: V2Balances = {
+  return {
     tokenBalance: tokenBalance.div(TEN_POW_18),
     wethBalance: wethBalance.div(TEN_POW_18),
   }
-  return response
 }

--- a/src/utils/poolData/types.ts
+++ b/src/utils/poolData/types.ts
@@ -1,0 +1,10 @@
+import { BigNumber } from "ethers";
+
+export type LiquidityBalance = {
+    tokenBalance: BigNumber,
+    wethBalance: BigNumber,
+}
+
+export type MaxTradeResponse = {
+    size: BigNumber,
+}

--- a/src/utils/poolData/uniswapV2.ts
+++ b/src/utils/poolData/uniswapV2.ts
@@ -8,15 +8,11 @@ import {
 
 import { WETH } from 'utils/constants/tokens'
 import { getProvider } from 'utils/provider'
-
-type V2Balances = {
-  tokenBalance: BigNumber
-  wethBalance: BigNumber
-}
+import { LiquidityBalance } from './types'
 
 export async function getUniswapV2Liquidity(
   tokenAddress: string
-): Promise<V2Balances> {
+): Promise<LiquidityBalance> {
   const provider = getProvider()
   const factoryInstance = await new Contract(
     UNI_V2_FACTORY,
@@ -31,9 +27,8 @@ export async function getUniswapV2Liquidity(
   )
   const [tokenBalance, wethBalance] = await pairContract.getReserves()
 
-  const response: V2Balances = {
+  return {
     tokenBalance: tokenBalance.div(TEN_POW_18),
     wethBalance: wethBalance.div(TEN_POW_18),
   }
-  return response
 }

--- a/src/utils/poolData/uniswapV3.ts
+++ b/src/utils/poolData/uniswapV3.ts
@@ -5,17 +5,13 @@ import { abi as V3_FACTORY_ABI } from '@uniswap/v3-core/artifacts/contracts/Unis
 import { ADDRESS_ZERO, TEN_POW_18 } from '../constants/constants'
 import { getProvider } from '../provider'
 import { WETH, ERC20_ABI } from 'utils/constants/tokens'
+import { LiquidityBalance } from './types'
 
 const UNI_V3_FACTORY = '0x1F98431c8aD98523631AE4a59f267346ea31F984'
 
-type V3Balances = {
-  tokenBalance: BigNumber
-  wethBalance: BigNumber
-}
-
 export async function getUniswapV3Liquidity(
   tokenAddress: string
-): Promise<V3Balances> {
+): Promise<LiquidityBalance> {
   const provider = getProvider()
   const factoryInstance = await new Contract(
     UNI_V3_FACTORY,
@@ -35,9 +31,8 @@ export async function getUniswapV3Liquidity(
 
   const tokenBalance: BigNumber = await tokenContract.balanceOf(poolAddress)
   const wethBalance: BigNumber = await wethContract.balanceOf(poolAddress)
-  const response: V3Balances = {
+  return {
     tokenBalance: tokenBalance.div(TEN_POW_18),
     wethBalance: wethBalance.div(TEN_POW_18),
   }
-  return response
 }

--- a/src/utils/poolData/zeroEx.ts
+++ b/src/utils/poolData/zeroEx.ts
@@ -29,7 +29,7 @@ export async function getZeroExLiquidity(tokenAddress: string): Promise<Liquidit
 export async function getZeroExQuote(tokenAddress: string, maxSlippagePercent: number): Promise<MaxTradeResponse> {
     const requestUrl = `${mainNet}/${pricePath}?`
         + `sellToken=ETH&`
-        + `sellAmount=${constants.WeiPerEther.mul(50)}&`
+        + `sellAmount=${constants.WeiPerEther.mul(1)}&`
         + `buyToken=${tokenAddress}&`
         + `slippagePercentage=${maxSlippagePercent / 100}`;
 

--- a/src/utils/poolData/zeroEx.ts
+++ b/src/utils/poolData/zeroEx.ts
@@ -29,10 +29,13 @@ export async function getZeroExLiquidity(tokenAddress: string): Promise<Liquidit
  * @returns 
  */
 export async function getZeroExQuote(tokenAddress: string, maxSlippagePercent: number): Promise<MaxTradeResponse> {
+    if (maxSlippagePercent <= 0) {
+        throw new Error('Invalid max slippage percent')
+    }
     const quote1 = await getQuote(tokenAddress, "WETH", 1, maxSlippagePercent);
-    let inputAmount = 2;
     let quote2;
     let slippagePercent = 0;
+    let inputAmount = 2;
     while (slippagePercent * 100 < maxSlippagePercent) {
         quote2 = await getQuote(tokenAddress, "WETH", inputAmount, maxSlippagePercent);
         slippagePercent = (parseFloat(quote1.price) - parseFloat(quote2.price)) / parseFloat(quote1.price);

--- a/src/utils/poolData/zeroEx.ts
+++ b/src/utils/poolData/zeroEx.ts
@@ -1,4 +1,5 @@
 import { BigNumber, constants } from "ethers";
+import { ZERO } from "utils/constants/constants";
 import { LiquidityBalance, MaxTradeResponse } from "./types";
 
 const mainNet = "https://api.0x.org";
@@ -6,9 +7,8 @@ const pricePath = "swap/v1/price";
 
 type ZeroExQuote = {
     price: string,
-    gas: string,
-    value: string,
     buyAmount: string,
+    buyTokenToEthRate: string,
 }
 
 /**
@@ -27,20 +27,39 @@ export async function getZeroExLiquidity(tokenAddress: string): Promise<Liquidit
  * @returns 
  */
 export async function getZeroExQuote(tokenAddress: string, maxSlippagePercent: number): Promise<MaxTradeResponse> {
-    const requestUrl = `${mainNet}/${pricePath}?`
-        + `sellToken=ETH&`
-        + `sellAmount=${constants.WeiPerEther.mul(1)}&`
-        + `buyToken=${tokenAddress}&`
-        + `slippagePercentage=${maxSlippagePercent / 100}`;
+    let slippage = 0;
+    let quote = await getQuote(tokenAddress, "WETH", 1, maxSlippagePercent);;
+    // let sellAmount = 1;
+    // while (slippage < maxSlippagePercent) {
+    //     quote = await getQuote(tokenAddress, "WETH", sellAmount, maxSlippagePercent);
+    //     slippage = (parseFloat(quote.buyTokenToEthRate) - parseFloat(quote.price)) / parseFloat(quote.buyTokenToEthRate);
+    //     sellAmount += 10;
+    //     await new Promise(f => setTimeout(f, 10000));
+    // }
+    // if (quote == null) {
+    //     throw new Error('No quote retrieved');
+    // }
 
+    if (BigNumber.from(quote.buyAmount).eq(0)) {
+        return {
+            size: BigNumber.from(constants.Zero),
+        }
+    }
+    return {
+        size: BigNumber.from(quote.buyAmount),
+    }
+}
+
+async function getQuote(buyToken: string, sellToken: string, sellAmount: number, slippagePercent: number): Promise<ZeroExQuote> {
+    const requestUrl = `${mainNet}/${pricePath}?`
+        + `sellToken=${sellToken}&`
+        + `sellAmount=${constants.WeiPerEther.mul(sellAmount)}&`
+        + `buyToken=${buyToken}&`
+        + `slippagePercentage=${slippagePercent / 100}`;
     console.log(requestUrl);
     const res = await fetch(requestUrl);
     if (!res.ok) {
         throw new Error('Failed to retrieve quote')
     }
-    const body: ZeroExQuote = await res.json();
-    console.log(body);
-    return {
-        size: BigNumber.from(body.buyAmount),
-    }
+    return await res.json();
 }

--- a/src/utils/poolData/zeroEx.ts
+++ b/src/utils/poolData/zeroEx.ts
@@ -1,0 +1,46 @@
+import { JsonRpcProvider } from "@ethersproject/providers";
+import { BigNumber, ethers } from "ethers";
+import { LiquidityBalance, MaxTradeResponse } from "./types";
+
+const mainNet = "https://api.0x.org";
+const pricePath = "swap/v1/price";
+
+type ZeroExQuote = {
+    price: string,
+    gas: string,
+    value: string,
+    buyAmount: string,
+}
+
+/**
+ * As a dex aggregator, it has no inherent sources of liquidity.
+ */
+export async function getZeroExLiquidity(tokenAddress: string): Promise<LiquidityBalance> {
+    return {
+        tokenBalance: BigNumber.from(0),
+        wethBalance: BigNumber.from(0),
+    }
+}
+
+/**
+ * @param tokenAddress
+ * @param maxSlippagePercent 0.5% -> 0.005
+ * @returns 
+ */
+export async function getZeroExQuote(tokenAddress: string, maxSlippagePercent: number): Promise<MaxTradeResponse> {
+    const requestUrl = `${mainNet}/${pricePath}?`
+        + `sellToken=WETH&`
+        + `buyToken=${tokenAddress}&`
+        + `sellAmount=10000000&`
+        + `slippagePercentage=${maxSlippagePercent / 100}`;
+
+    const res = await fetch(requestUrl);
+    if (!res.ok) {
+        throw new Error('Failed to retrieve quote')
+    }
+    const body: ZeroExQuote = await res.json();
+    console.log(body);
+    return {
+        size: BigNumber.from(body.value),
+    }
+}

--- a/src/utils/poolData/zeroEx.ts
+++ b/src/utils/poolData/zeroEx.ts
@@ -32,18 +32,18 @@ export async function getZeroExQuote(tokenAddress: string, maxSlippagePercent: n
     if (maxSlippagePercent <= 0) {
         throw new Error('Invalid max slippage percent')
     }
-    const quote1 = await getQuote(tokenAddress, "WETH", 1, maxSlippagePercent);
-    let quote2;
+    const baseQuote = await getQuote(tokenAddress, "WETH", 1, maxSlippagePercent);
+    let maxTradeQuote;
     let slippagePercent = 0;
-    let inputAmount = 2;
+    let tradeAmount = 2;
     while (slippagePercent * 100 < maxSlippagePercent) {
-        quote2 = await getQuote(tokenAddress, "WETH", inputAmount, maxSlippagePercent);
-        slippagePercent = (parseFloat(quote1.price) - parseFloat(quote2.price)) / parseFloat(quote1.price);
-        inputAmount++;
+        maxTradeQuote = await getQuote(tokenAddress, "WETH", tradeAmount, maxSlippagePercent);
+        slippagePercent = (parseFloat(baseQuote.price) - parseFloat(maxTradeQuote.price)) / parseFloat(baseQuote.price);
+        tradeAmount++;
     }
 
     return {
-        size: BigNumber.from(quote2?.buyAmount),
+        size: BigNumber.from(maxTradeQuote?.buyAmount),
     }
 }
 

--- a/src/utils/poolData/zeroEx.ts
+++ b/src/utils/poolData/zeroEx.ts
@@ -44,7 +44,6 @@ export async function getZeroExQuote(tokenAddress: string, maxSlippagePercent: n
     if (quote == null) {
         throw new Error('No quote retrieved');
     }
-    console.log(quote)
 
     if (BigNumber.from(quote.buyAmount).eq(0)) {
         return {

--- a/src/utils/poolData/zeroEx.ts
+++ b/src/utils/poolData/zeroEx.ts
@@ -1,5 +1,4 @@
-import { JsonRpcProvider } from "@ethersproject/providers";
-import { BigNumber, ethers } from "ethers";
+import { BigNumber, constants } from "ethers";
 import { LiquidityBalance, MaxTradeResponse } from "./types";
 
 const mainNet = "https://api.0x.org";
@@ -29,11 +28,12 @@ export async function getZeroExLiquidity(tokenAddress: string): Promise<Liquidit
  */
 export async function getZeroExQuote(tokenAddress: string, maxSlippagePercent: number): Promise<MaxTradeResponse> {
     const requestUrl = `${mainNet}/${pricePath}?`
-        + `sellToken=WETH&`
+        + `sellToken=ETH&`
+        + `sellAmount=${constants.WeiPerEther.mul(50)}&`
         + `buyToken=${tokenAddress}&`
-        + `sellAmount=10000000&`
         + `slippagePercentage=${maxSlippagePercent / 100}`;
 
+    console.log(requestUrl);
     const res = await fetch(requestUrl);
     if (!res.ok) {
         throw new Error('Failed to retrieve quote')
@@ -41,6 +41,6 @@ export async function getZeroExQuote(tokenAddress: string, maxSlippagePercent: n
     const body: ZeroExQuote = await res.json();
     console.log(body);
     return {
-        size: BigNumber.from(body.value),
+        size: BigNumber.from(body.buyAmount),
     }
 }

--- a/src/utils/poolData/zeroEx.ts
+++ b/src/utils/poolData/zeroEx.ts
@@ -29,43 +29,19 @@ export async function getZeroExLiquidity(tokenAddress: string): Promise<Liquidit
  * @returns 
  */
 export async function getZeroExQuote(tokenAddress: string, maxSlippagePercent: number): Promise<MaxTradeResponse> {
-    const price = await getPrice(tokenAddress, "WETH", maxSlippagePercent);
-    console.log(price);
-    let slippage = 0;
-    let quote;
-    let numWeth = 1;
-    while (slippage < maxSlippagePercent) {
-        quote = await getQuote(tokenAddress, "WETH", numWeth, maxSlippagePercent);
-        slippage = (parseFloat(quote.buyTokenToEthRate) - parseFloat(quote.guaranteedPrice)) / parseFloat(quote.buyTokenToEthRate);
-        slippage = slippage * 100;
-        numWeth++;
-        await new Promise(f => setTimeout(f, 250));
-    }
-    if (quote == null) {
-        throw new Error('No quote retrieved');
+    const quote1 = await getQuote(tokenAddress, "WETH", 1, maxSlippagePercent);
+    let inputAmount = 2;
+    let quote2;
+    let slippagePercent = 0;
+    while (slippagePercent * 100 < maxSlippagePercent) {
+        quote2 = await getQuote(tokenAddress, "WETH", inputAmount, maxSlippagePercent);
+        slippagePercent = (parseFloat(quote1.price) - parseFloat(quote2.price)) / parseFloat(quote1.price);
+        inputAmount++;
     }
 
-    if (BigNumber.from(quote.buyAmount).eq(0)) {
-        return {
-            size: BigNumber.from(constants.Zero),
-        }
-    }
     return {
-        size: BigNumber.from(quote.buyAmount),
+        size: BigNumber.from(quote2?.buyAmount),
     }
-}
-
-async function getPrice(buyToken: string, sellToken: string, slippagePercent: number): Promise<ZeroExQuote> {
-    const requestUrl = `${mainNet}/${pricePath}?`
-        + `sellToken=${sellToken}&`
-        + `sellAmount=${constants.WeiPerEther}&`
-        + `buyToken=${buyToken}&`
-        + `slippagePercentage=${slippagePercent / 100}`;
-    const res = await fetch(requestUrl);
-    if (!res.ok) {
-        throw new Error('Failed to retrieve quote')
-    }
-    return await res.json();
 }
 
 async function getQuote(buyToken: string, sellToken: string, sellAmount: number, slippagePercent: number): Promise<ZeroExQuote> {


### PR DESCRIPTION
0x api doesn't provide price impact API. To work out the max trade for a given slippage, get the base quote for 1 WETH. Then loop and get quotes for increasing WETH until we reach our max slippage percent. Does a best approximation for the max trade size using 0x api